### PR TITLE
Set Java 1.6 as a target VM version

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -40,6 +40,8 @@
         <javac compiler="javac1.6"
                includeantruntime="false"
                encoding="UTF-8"
+               source="1.6"
+               target="1.6"
                debug="on"
                destdir="dist">
             <classpath refid="master-classpath"/>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -18,6 +18,19 @@
         <url>https://github.com/scireum/server-sass.git</url>
         <connection>https://github.com/scireum/server-sass.git</connection>
     </scm>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- or whatever version you use -->
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <developers>
         <developer>
             <id>aha</id>


### PR DESCRIPTION
Hi,

We would like to use your library in our project. Our baseline JDK version is 1.6.
I noticed that you don't use any 1.7+ specific features. May I ask you to accept it as baseline for time being? 

Thanks,
Anton
