### PR TITLE
Throws no error anymore for the &:: selector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>3.11.4</version>
     </parent>
     <artifactId>server-sass</artifactId>
-    <version>4.2</version>
+    <version>4.2.1</version>
     <packaging>jar</packaging>
 
     <name>server-sass</name>

--- a/src/main/java/org/serversass/Parser.java
+++ b/src/main/java/org/serversass/Parser.java
@@ -408,6 +408,13 @@ public class Parser {
                 selector.add(":" + tokenizer.consume().getContents());
             }
         }
+        if (tokenizer.more() && tokenizer.current().isSymbol("&::")) {
+            tokenizer.consume();
+            if (tokenizer.current().is(Token.TokenType.ID)) {
+                selector.add("&");
+                selector.add("::" + tokenizer.consume().getContents());
+            }
+        }
         if (tokenizer.more() && tokenizer.current().isSymbol("::") && tokenizer.next().is(Token.TokenType.ID)) {
             tokenizer.consume();
             selector.add("::" + tokenizer.consume().getContents());

--- a/src/test/resources/selectors.css
+++ b/src/test/resources/selectors.css
@@ -49,6 +49,11 @@ div::after {
     content: "💩";
 }
 
+div::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+}
+
 #test * {
     box-sizing: content-box;
 }

--- a/src/test/resources/selectors.scss
+++ b/src/test/resources/selectors.scss
@@ -54,6 +54,13 @@ div::after {
   content: "💩";
 }
 
+div {
+  &::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+  }
+}
+
 // We expect * to work and stay the same
 #test * {
   box-sizing: content-box;


### PR DESCRIPTION
```
progress {
  &::-webkit-progress-bar {
    ...
  }
}
```

## before

`ERROR 119: 4: Unexpected Token: &::`

## after

💚 

```
progress::-webkit-progress-bar {
    ...
}
```

