### PR TITLE
SIRI-56: Parses arguments in pseudo-class sub sections

### DIFF
--- a/src/main/java/org/serversass/Parser.java
+++ b/src/main/java/org/serversass/Parser.java
@@ -409,13 +409,23 @@ public class Parser {
             selector.add("::" + tokenizer.consume().getContents());
         }
     }
-    
+
+    /**
+     * Parses and consumes selector prefixes which add pseudo-classes ('&:') or pseudo-elements ('&::') to an existing selector, 
+     * Arguments on pseudo classes like '&:not(.class)' are also parsed and consumed.
+     * For valid input like e.g. '&::after' , '&:first-child' , '&:not(.class)' two selectors are added to the given List:
+     * 1. '&'
+     * 2. the pseudo-class/element e.g. '::after' , ':first-child' , ':not(.class)'
+     * 
+     * @param selector the List to which the selectors are added.
+     */
     private void consumePseudoInSelectorPrefix(List<String> selector) {
-        String pseudoOperator = tokenizer.current().getSource().substring(1); // either : or ::
+        String pseudoOperator = tokenizer.current().getSource().substring(1);
         tokenizer.consume();
         if (tokenizer.current().is(Token.TokenType.ID)) {
             selector.add("&");
             StringBuilder sb = new StringBuilder(pseudoOperator + tokenizer.consume().getContents());
+            // Consume arguments like :nth-child(2)
             if (tokenizer.current().isSymbol("(")) {
                 consumeArgument(sb);
             }

--- a/src/main/java/org/serversass/Parser.java
+++ b/src/main/java/org/serversass/Parser.java
@@ -411,10 +411,10 @@ public class Parser {
     }
 
     /**
-     * Parses and consumes selector prefixes which add pseudo-classes ('&:') or pseudo-elements ('&::') to an existing selector, 
-     * Arguments on pseudo classes like '&:not(.class)' are also parsed and consumed.
-     * For valid input like e.g. '&::after' , '&:first-child' , '&:not(.class)' two selectors are added to the given List:
-     * 1. '&'
+     * Parses and consumes selector prefixes which add pseudo-classes ('&amp;:') or pseudo-elements ('&amp;::') to an existing selector, 
+     * Arguments on pseudo classes like '&amp;:not(.class)' are also parsed and consumed.
+     * For valid input like e.g. '&amp;::after' , '&amp;:first-child' , '&amp;:not(.class)' two selectors are added to the given List:
+     * 1. '&amp;'
      * 2. the pseudo-class/element e.g. '::after' , ':first-child' , ':not(.class)'
      * 
      * @param selector the List to which the selectors are added.

--- a/src/main/java/org/serversass/Parser.java
+++ b/src/main/java/org/serversass/Parser.java
@@ -359,7 +359,7 @@ public class Parser {
     }
 
     /*
-     * CSS and therefore als SASS supports a wide range or complex selector strings. The following method
+     * CSS and therefore also SASS supports a wide range or complex selector strings. The following method
      * parses such selectors while performing basic consistency checks
      */
     private List<String> parseSelector() {
@@ -401,23 +401,25 @@ public class Parser {
         if (tokenizer.more() && tokenizer.current().isSymbol("&")) {
             selector.add(tokenizer.consume().getTrigger());
         }
-        if (tokenizer.more() && tokenizer.current().isSymbol("&:")) {
-            tokenizer.consume();
-            if (tokenizer.current().is(Token.TokenType.ID)) {
-                selector.add("&");
-                selector.add(":" + tokenizer.consume().getContents());
-            }
-        }
-        if (tokenizer.more() && tokenizer.current().isSymbol("&::")) {
-            tokenizer.consume();
-            if (tokenizer.current().is(Token.TokenType.ID)) {
-                selector.add("&");
-                selector.add("::" + tokenizer.consume().getContents());
-            }
+        if (tokenizer.more() && (tokenizer.current().isSymbol("&:") || tokenizer.current().isSymbol("&::"))) {
+            consumePseudoInSelectorPrefix(selector);
         }
         if (tokenizer.more() && tokenizer.current().isSymbol("::") && tokenizer.next().is(Token.TokenType.ID)) {
             tokenizer.consume();
             selector.add("::" + tokenizer.consume().getContents());
+        }
+    }
+    
+    private void consumePseudoInSelectorPrefix(List<String> selector) {
+        String pseudoOperator = tokenizer.current().getSource().substring(1); // either : or ::
+        tokenizer.consume();
+        if (tokenizer.current().is(Token.TokenType.ID)) {
+            selector.add("&");
+            StringBuilder sb = new StringBuilder(pseudoOperator + tokenizer.consume().getContents());
+            if (tokenizer.current().isSymbol("(")) {
+                consumeArgument(sb);
+            }
+            selector.add(sb.toString());
         }
     }
 

--- a/src/test/java/org/serversass/SassTest.java
+++ b/src/test/java/org/serversass/SassTest.java
@@ -75,6 +75,11 @@ public class SassTest {
     public void testGridAreas() {
         compare("grid.scss", "grid.css");
     }
+    
+    @Test
+    public void testNotSelector() {
+        compare("not.scss", "not.css");
+    }
 
     private void compare(String scssFile, String cssFile) {
         try {

--- a/src/test/resources/not.css
+++ b/src/test/resources/not.css
@@ -1,0 +1,12 @@
+div:not(.class) {
+    color: green;
+}
+
+div {
+    width: 12px;
+}
+
+div:not(.class) {
+    height: 12px;
+}
+

--- a/src/test/resources/not.scss
+++ b/src/test/resources/not.scss
@@ -1,0 +1,11 @@
+div:not(.class) {
+  color: green;
+}
+
+div {
+  width: 12px;
+
+  &:not(.class) {
+    height: 12px;
+  }
+}


### PR DESCRIPTION
Previously, sub-sections like &:not(.class) or &:nth-child(2) threw Exceptions since the arguments were never parsed and parser could not parse a selector starting with '('