### PR TITLE
Adds support for CSS variables ans pseudo selectors.

### DIFF
--- a/src/main/java/org/serversass/Parser.java
+++ b/src/main/java/org/serversass/Parser.java
@@ -104,7 +104,12 @@ public class Parser {
                 return true;
             }
             // Support vendor specific and class selectors like -moz-border-radius or .test
-            return (input.current().is('-') || input.current().is('.')) && input.next().isLetter();
+            if ((input.current().is('-') || input.current().is('.')) && input.next().isLetter()) {
+                return true;
+            }
+
+            // Add support for CSS variables which look like --variable-name
+            return input.current().is('-') && input.next().is('-') && input.next(2).isLetter();
         }
 
         @Override
@@ -407,6 +412,10 @@ public class Parser {
         if (tokenizer.more() && tokenizer.current().isSymbol("::") && tokenizer.next().is(Token.TokenType.ID)) {
             tokenizer.consume();
             selector.add("::" + tokenizer.consume().getContents());
+        }
+        if (tokenizer.more() && tokenizer.current().isSymbol(":") && tokenizer.next().is(Token.TokenType.ID)) {
+            tokenizer.consume();
+            selector.add(":" + tokenizer.consume().getContents());
         }
     }
 

--- a/src/test/java/org/serversass/SassTest.java
+++ b/src/test/java/org/serversass/SassTest.java
@@ -72,6 +72,11 @@ public class SassTest {
     }
 
     @Test
+    public void testCssVariables() {
+        compare("css-variables.scss", "css-variables.css");
+    }
+
+    @Test
     public void testGridAreas() {
         compare("grid.scss", "grid.css");
     }

--- a/src/test/resources/css-variables.css
+++ b/src/test/resources/css-variables.css
@@ -1,0 +1,7 @@
+:root {
+    --main-bg-color: brown;
+}
+
+test {
+    fill: var(--main-bg-color);
+}

--- a/src/test/resources/css-variables.scss
+++ b/src/test/resources/css-variables.scss
@@ -1,0 +1,7 @@
+:root {
+  --main-bg-color: brown;
+}
+
+test {
+  fill: var(--main-bg-color);
+}


### PR DESCRIPTION
CSS variables start with "--" which wasn't detected as
valid identifier. This has now been changed so that
-- + any letter is a valid start or an identifier.

Also a selected didn't support a single ":" at its start.
To support pseudo elements like :root, we now support
this as valid selector start.